### PR TITLE
Load Google Fonts over https instead of http

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 
 		<meta charset="utf-8">
 
-		<link href="http://fonts.googleapis.com/css?family=Arvo:regular,italic,bold" rel="stylesheet" type="text/css">
+		<link href="https://fonts.googleapis.com/css?family=Arvo:regular,italic,bold" rel="stylesheet" type="text/css">
 
 		<style>
 


### PR DESCRIPTION
Replace `http://` with `https://` when calling the font stylesheet in order to send [Arvo](https://fonts.google.com/specimen/Arvo) to modern browsers.