### PR TITLE
Simple pedantic update: use ≥ instead of >=

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 
 				<fieldset>
 					<input class="pointer" type="checkbox" ng-model="options.jQuery" ng-change="updateBookmarklet(options)"></input>
-					<label class="pointer" for="reqjq">Make sure a modern version (&gt;= 1.7) of <a href="http://jquery.com">jQuery</a> is available for your code.</label>
+					<label class="pointer" for="reqjq">Make sure a modern version (≥ 1.7) of <a href="http://jquery.com">jQuery</a> is available for your code.</label>
 				</fieldset>
 
 			</div>


### PR DESCRIPTION
I use this tool all the time, but I prefer to see `>=` only in code and to see the more elegant `≥` face the public.