### PR TITLE
BUGFIX iife: `...{${code}\n}();` instead of `...{${code}}();`

### DIFF
--- a/bookmarkleter.js
+++ b/bookmarkleter.js
@@ -31,7 +31,7 @@ const jquery = code => `void function ($) {
   document.getElementsByTagName('head')[0].appendChild(s);
 }(window.jQuery);`;
 
-const iife = code => `void function () {${code}}();`;
+const iife = code => `void function () {${code}\n}();`;
 const minify = code => babelMinify( code, { mangle: true } ).code;
 const prefix = code => `javascript:${code}`;
 const transpile = code => transform( code, { comments: false, filename: 'bookmarklet.js', presets: [ 'env' ], targets: '> 2%, not dead' } ).code.replace( /\n+/g, '' );


### PR DESCRIPTION
inserted newline to beginning of wrapper's closing string -- fixes [Issue #29](https://github.com/chriszarate/bookmarkleter/issues/29)

```
var x;
var foo = bar?.baz ?? x;
//
```

^ this test case currently results in minifying to the following -- which causes a red box error "unknown: Unexpected token (3:6) 1 | void function () {var x; 2 | var foo = bar?.baz ?? x; > 3 | //}(); | ^"

```
void function () {var x; 2 | var foo = bar?.baz ?? x; > 3 | //}();
```

the bugfix now makes it minify to...
```
void function () {var x; 2 | var foo = bar?.baz ?? x; > 3 | //
}();
````
^ newline added before "}();"

NOTE: this definitely fixes the bug, while it is unclear if babel-minify allows any kind of value passed to "comments:" property to fix this.

